### PR TITLE
cleanup of animated, added text and images

### DIFF
--- a/android/.idea/misc.xml
+++ b/android/.idea/misc.xml
@@ -24,7 +24,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_7" default="true" project-jdk-name="1.8 (1)" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/ios/SyrNative/SyrNative.xcodeproj/project.pbxproj
+++ b/ios/SyrNative/SyrNative.xcodeproj/project.pbxproj
@@ -46,6 +46,10 @@
 		D2B1F5701FE34B17004A42EF /* SyrStyler.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B1F56E1FE34B17004A42EF /* SyrStyler.m */; };
 		D2B1F5731FE499B1004A42EF /* SyrTouchableOpacity.h in Headers */ = {isa = PBXBuildFile; fileRef = D2B1F5711FE499B1004A42EF /* SyrTouchableOpacity.h */; };
 		D2B1F5741FE499B1004A42EF /* SyrTouchableOpacity.m in Sources */ = {isa = PBXBuildFile; fileRef = D2B1F5721FE499B1004A42EF /* SyrTouchableOpacity.m */; };
+		D2CE4DFB200E8269002B7B40 /* SyrAnimatedImage.h in Headers */ = {isa = PBXBuildFile; fileRef = D2CE4DF9200E8269002B7B40 /* SyrAnimatedImage.h */; };
+		D2CE4DFC200E8269002B7B40 /* SyrAnimatedImage.m in Sources */ = {isa = PBXBuildFile; fileRef = D2CE4DFA200E8269002B7B40 /* SyrAnimatedImage.m */; };
+		D2CE4DFF200E8365002B7B40 /* SyrAnimatedText.h in Headers */ = {isa = PBXBuildFile; fileRef = D2CE4DFD200E8365002B7B40 /* SyrAnimatedText.h */; };
+		D2CE4E00200E8365002B7B40 /* SyrAnimatedText.m in Sources */ = {isa = PBXBuildFile; fileRef = D2CE4DFE200E8365002B7B40 /* SyrAnimatedText.m */; };
 		D2D3122A1F9520AF008A9CCC /* SyrEventHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = D2D312281F9520AF008A9CCC /* SyrEventHandler.h */; };
 		D2D3122B1F9520AF008A9CCC /* SyrEventHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = D2D312291F9520AF008A9CCC /* SyrEventHandler.m */; };
 		D2D3122E1F955D18008A9CCC /* SyrView.h in Headers */ = {isa = PBXBuildFile; fileRef = D2D3122C1F955D18008A9CCC /* SyrView.h */; };
@@ -112,6 +116,10 @@
 		D2B1F56E1FE34B17004A42EF /* SyrStyler.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SyrStyler.m; sourceTree = "<group>"; };
 		D2B1F5711FE499B1004A42EF /* SyrTouchableOpacity.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyrTouchableOpacity.h; sourceTree = "<group>"; };
 		D2B1F5721FE499B1004A42EF /* SyrTouchableOpacity.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SyrTouchableOpacity.m; sourceTree = "<group>"; };
+		D2CE4DF9200E8269002B7B40 /* SyrAnimatedImage.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyrAnimatedImage.h; sourceTree = "<group>"; };
+		D2CE4DFA200E8269002B7B40 /* SyrAnimatedImage.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SyrAnimatedImage.m; sourceTree = "<group>"; };
+		D2CE4DFD200E8365002B7B40 /* SyrAnimatedText.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SyrAnimatedText.h; sourceTree = "<group>"; };
+		D2CE4DFE200E8365002B7B40 /* SyrAnimatedText.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = SyrAnimatedText.m; sourceTree = "<group>"; };
 		D2D312281F9520AF008A9CCC /* SyrEventHandler.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SyrEventHandler.h; sourceTree = "<group>"; };
 		D2D312291F9520AF008A9CCC /* SyrEventHandler.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = SyrEventHandler.m; sourceTree = "<group>"; };
 		D2D3122C1F955D18008A9CCC /* SyrView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SyrView.h; sourceTree = "<group>"; };
@@ -195,6 +203,10 @@
 				D2DE8FFA1FC0E46B00EEF358 /* SyrStackView.m */,
 				D2B1F5711FE499B1004A42EF /* SyrTouchableOpacity.h */,
 				D2B1F5721FE499B1004A42EF /* SyrTouchableOpacity.m */,
+				D2CE4DF9200E8269002B7B40 /* SyrAnimatedImage.h */,
+				D2CE4DFA200E8269002B7B40 /* SyrAnimatedImage.m */,
+				D2CE4DFD200E8365002B7B40 /* SyrAnimatedText.h */,
+				D2CE4DFE200E8365002B7B40 /* SyrAnimatedText.m */,
 			);
 			name = Components;
 			sourceTree = "<group>";
@@ -268,6 +280,7 @@
 				D266C49A1F9ABAE400BB0A90 /* SyrButton.h in Headers */,
 				D2DE8FF71FBF608D00EEF358 /* SyrLinearGradient.h in Headers */,
 				D2D7E0351F0F672D0039C3A9 /* SyrNative.h in Headers */,
+				D2CE4DFB200E8269002B7B40 /* SyrAnimatedImage.h in Headers */,
 				D2B1F56F1FE34B17004A42EF /* SyrStyler.h in Headers */,
 				D2D3122E1F955D18008A9CCC /* SyrView.h in Headers */,
 				D266C4A71F9B275E00BB0A90 /* SyrAnimatedView.h in Headers */,
@@ -282,6 +295,7 @@
 				D266C4961F9AB65200BB0A90 /* SyrImage.h in Headers */,
 				D266C47B1F9AAD0700BB0A90 /* SyrComponent.h in Headers */,
 				D266C49E1F9ABE4E00BB0A90 /* SyrAnimator.h in Headers */,
+				D2CE4DFF200E8365002B7B40 /* SyrAnimatedText.h in Headers */,
 				D2B1F5731FE499B1004A42EF /* SyrTouchableOpacity.h in Headers */,
 				D229B70C1FD21352004D651B /* SyrAnimationDelegate.h in Headers */,
 				D2D7E06A1F0F69050039C3A9 /* SyrCore.h in Headers */,
@@ -404,6 +418,7 @@
 				D24A90621F86C2BF003DAD64 /* SyrBridge.m in Sources */,
 				D271B2AA1FFED873004603B4 /* SyrInfoBox.m in Sources */,
 				D2D7E06B1F0F69050039C3A9 /* SyrCore.m in Sources */,
+				D2CE4E00200E8365002B7B40 /* SyrAnimatedText.m in Sources */,
 				D2DE8FF81FBF608D00EEF358 /* SyrLinearGradient.m in Sources */,
 				D2DE8FFC1FC0E46B00EEF358 /* SyrStackView.m in Sources */,
 				D2D3122B1F9520AF008A9CCC /* SyrEventHandler.m in Sources */,
@@ -420,6 +435,7 @@
 				D2B1F5701FE34B17004A42EF /* SyrStyler.m in Sources */,
 				D266C4801F9AAD2000BB0A90 /* SyrText.m in Sources */,
 				D266C49B1F9ABAE400BB0A90 /* SyrButton.m in Sources */,
+				D2CE4DFC200E8269002B7B40 /* SyrAnimatedImage.m in Sources */,
 				D266C49F1F9ABE4E00BB0A90 /* SyrAnimator.m in Sources */,
 				D29AD6A21FA536D500DE7CF0 /* SyrScrollView.m in Sources */,
 				D229B70D1FD21352004D651B /* SyrAnimationDelegate.m in Sources */,

--- a/ios/SyrNative/SyrNative/SyrAnimatedImage.h
+++ b/ios/SyrNative/SyrNative/SyrAnimatedImage.h
@@ -1,0 +1,12 @@
+//
+//  SyrAnimatedImage.h
+//  SyrNative
+//
+//  Created by Anderson,Derek on 1/16/18.
+//  Copyright © 2018 Anderson,Derek. All rights reserved.
+//
+#import "SyrComponent.h"
+
+@interface SyrAnimatedImage : SyrComponent
+
+@end

--- a/ios/SyrNative/SyrNative/SyrAnimatedImage.m
+++ b/ios/SyrNative/SyrNative/SyrAnimatedImage.m
@@ -1,0 +1,18 @@
+//
+//  SyrAnimatedImage.m
+//  SyrNative
+//
+//  Created by Anderson,Derek on 1/16/18.
+//  Copyright © 2018 Anderson,Derek. All rights reserved.
+//
+
+#import "SyrAnimatedImage.h"
+#import "SyrImage.h"
+
+@implementation SyrAnimatedImage
+
++(NSObject*) render: (NSDictionary*) component withInstance: (NSObject*) componentInstance {
+  return [SyrImage render:component withInstance:componentInstance];
+}
+
+@end

--- a/ios/SyrNative/SyrNative/SyrAnimatedText.h
+++ b/ios/SyrNative/SyrNative/SyrAnimatedText.h
@@ -1,0 +1,13 @@
+//
+//  SyrAnimatedText.h
+//  SyrNative
+//
+//  Created by Anderson,Derek on 1/16/18.
+//  Copyright © 2018 Anderson,Derek. All rights reserved.
+//
+
+#import "SyrComponent.h"
+
+@interface SyrAnimatedText : SyrComponent
+
+@end

--- a/ios/SyrNative/SyrNative/SyrAnimatedText.m
+++ b/ios/SyrNative/SyrNative/SyrAnimatedText.m
@@ -1,0 +1,18 @@
+//
+//  SyrAnimatedText.m
+//  SyrNative
+//
+//  Created by Anderson,Derek on 1/16/18.
+//  Copyright © 2018 Anderson,Derek. All rights reserved.
+//
+
+#import "SyrAnimatedText.h"
+#import "SyrText.h"
+
+@implementation SyrAnimatedText
+
++(NSObject*) render: (NSDictionary*) component withInstance: (NSObject*) componentInstance {
+  return [SyrText render:component withInstance:componentInstance];
+}
+
+@end

--- a/ios/SyrNative/SyrNative/SyrAnimatedView.m
+++ b/ios/SyrNative/SyrNative/SyrAnimatedView.m
@@ -7,29 +7,12 @@
 //
 
 #import "SyrAnimatedView.h"
-#import "SyrStyler.h"
+#import "SyrView.h"
 
 @implementation SyrAnimatedView
 
 +(NSObject*) render: (NSDictionary*) component withInstance: (NSObject*) componentInstance  {
-  UIView* view;
-  
-  NSDictionary* style = [[[component objectForKey:@"instance"] objectForKey:@"attributes"] valueForKey:@"style"];
-  if(componentInstance != nil) {
-    view = (UIView*)componentInstance;
-    
-  } else {
-    view = [[UIView alloc] init];
-    view.frame = [SyrStyler styleFrame:style];
-  }
-  NSDictionary* state =	[[component objectForKey:@"instance"] objectForKey:@"state"];
-//
-//  if([state objectForKey:@"x"] != nil || [state objectForKey:@"x"] != nil) {
-//    NSLog(@"hello");
-//    [style setValue:[state objectForKey:@"x"] forKey:@"left"]
-//  }
-  
-  return [SyrStyler styleView:view withStyle:style];
+  return [SyrView render:component withInstance:componentInstance];
 }
 
 @end

--- a/lib/animated.js
+++ b/lib/animated.js
@@ -1,5 +1,7 @@
 import { Component } from './component';
 import { View } from './view';
+import { Image } from './image';
+import { Text } from './text';
 import { RasterManager } from './rastermanager';
 import { Utils } from './utils';
 
@@ -8,14 +10,31 @@ let callbacks = {};
 /**
  * Animated
  */
+const animationComplete = function animationComplete(event) {
+  // todo - clean this up
+  let animation = this.animation || this.parent.animation;
+  let callback = callbacks[event.animation.guid];
+  if (callback) callback(event);
+}
+
 class AnimatedView extends View {
   animationComplete(event) {
-    // todo - clean this up
-    let animation = this.animation || this.parent.animation;
-    let callback = callbacks[event.animation.guid];
-    if (callback) callback(event);
+    animationComplete.call(this, event);
   }
 }
+
+class AnimatedImage extends Image {
+  animationComplete(event) {
+    animationComplete.call(this, event);
+  }
+}
+
+class AnimatedText extends Text {
+  animationComplete(event) {
+    animationComplete.call(this, event);
+  }
+}
+
 
 /**
  * Animated Class. Sets up and prepares animations to be transported over the bridge
@@ -24,6 +43,8 @@ class animated extends Component {
   constructor() {
     super();
     this.View = AnimatedView;
+    this.Image = AnimatedImage;
+    this.text = AnimatedText;
     this.AnimationTargets = {};
   }
 
@@ -46,10 +67,10 @@ class animated extends Component {
    */
   Value(value) {
     this.value = value;
-    this.guid = Utils.guid();
     this.setValue = newValue => {
       this.value = newValue;
     };
+    this.guid = Utils.guid();
   }
   /**
    * Setups an Animation from the that is ready to send to the bridge.

--- a/samples/example.js
+++ b/samples/example.js
@@ -46,7 +46,14 @@ const styles = {
     left: 0,
     textAlign: 'center',
   },
+  image: {
+    width: PixelRatio.getPixelSizeForLayoutSize(241),
+    height: PixelRatio.getPixelSizeForLayoutSize(299),
+    top: (Dimensions.get('window').height/2) - (PixelRatio.getPixelSizeForLayoutSize(299)/2),
+    left: (Dimensions.get('window').width/2) - (PixelRatio.getPixelSizeForLayoutSize(241)/2)
+  }
 };
+
 class MyComponent extends Component {
   constructor() {
     // platform specific styling
@@ -55,18 +62,30 @@ class MyComponent extends Component {
     }
 
     super();
+
+    this.spinPiggyAnimation = new Animated.Value(0);
+    styles.image.transform = [{ rotatey: this.spinPiggyAnimation }];
   }
   render() {
     return (
-      <View style={styles.stage}>
+      <Animated.View style={styles.stage}>
         <Text style={styles.text}>Welcome to Syr Applications!</Text>
+        <Animated.Image source={{uri:"piggy"}} style={styles.image}/>
         <Button style={styles.button}>Test Button 1</Button>
-      </View>
+      </Animated.View>
     );
   }
+  spinPiggy() {
+    Animated.timing(this.spinPiggyAnimation, {
+      toValue: 360,
+      duration: 2000
+    }).start(()=>{
+      console.log('running again')
+      this.spinPiggy();
+    });
+  }
   componentDidMount() {
-    console.log('componentDidMount');
-    console.log(Platform.Version, Platform.OS, Platform.isWeb);
+    this.spinPiggy()
   }
 }
 


### PR DESCRIPTION
Cleaned up Animation code for iOS. It was copy and paste, but now that we've settled into a pattern for rendering. The Native classes will borrow render implementation from those classes that it derives from. 

logically we could do away with any Animated.Somethings as long as it's a view we can animate. We started down the path of having separate class structures in case something down the line came up. 

![2018-01-16 11_06_54](https://user-images.githubusercontent.com/328000/35007099-6cef3370-faad-11e7-9fe3-6cd30bc8cd8e.gif)
