### PR TITLE
add minor network calls for fetch POST/GET to walk around CORs in WKW…

### DIFF
--- a/ios/SyrNative/SyrNative/SyrNetworking.m
+++ b/ios/SyrNative/SyrNative/SyrNetworking.m
@@ -12,7 +12,7 @@
 
 SYR_EXPORT_MODULE()
 
-SYR_EXPORT_METHOD(get: (NSDictionary*) requestDict) {
+SYR_EXPORT_METHOD(request: (NSDictionary*) requestDict) {
   // fetch on the async queue
   dispatch_queue_t queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0ul);
   dispatch_async(queue, ^{
@@ -21,6 +21,21 @@ SYR_EXPORT_METHOD(get: (NSDictionary*) requestDict) {
     NSString* guid = [requestDict valueForKey:@"guid"];
     NSString* method = [requestDict valueForKey:@"method"];
     NSMutableURLRequest *request = [[NSMutableURLRequest alloc] init];
+    NSString* body = [requestDict valueForKey:@"body"];
+    id headers = [requestDict objectForKey:@"headers"];
+    
+    if(body != nil) {
+      NSData* postData = [body dataUsingEncoding:NSUTF8StringEncoding];
+      NSString *postLength = [NSString stringWithFormat:@"%lu", (unsigned long)[postData length]];
+      [request setHTTPBody: postData];
+      [request setValue:postLength forHTTPHeaderField:@"Content-Length"];
+    }
+
+    // set more headers here
+    for (id key in headers) {
+      [request setValue:[headers valueForKey:key]  forHTTPHeaderField:key];
+    }
+    
     [request setHTTPMethod:method];
     [request setURL:[NSURL URLWithString:requestUrl]];
     
@@ -30,7 +45,6 @@ SYR_EXPORT_METHOD(get: (NSDictionary*) requestDict) {
     // get data
     NSData *oResponseData = [NSURLConnection sendSynchronousRequest:request returningResponse:&responseCode error:&error];
     
-    
     // log error if not success just for info
     if([responseCode statusCode] != 200){
       NSLog(@"Error getting %@, HTTP status code %li", requestUrl, (long)[responseCode statusCode]);
@@ -39,7 +53,6 @@ SYR_EXPORT_METHOD(get: (NSDictionary*) requestDict) {
     // get the response
     NSString* response = [[NSString alloc] initWithData:oResponseData encoding:NSASCIIStringEncoding];
     NSNumber* statusCode = [NSNumber numberWithDouble:[responseCode statusCode]];
-    
     
     // send the response back
     [self sendEventWithName:@"NetworkingCallback" body:@{@"data": response, @"responseCode": statusCode, @"guid": guid}];

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -31,20 +31,19 @@ class networking {
   }
   fetch(url, opts) {
 
-    if(opts && opts.mode.toLowerCase() === 'bypass') {
+    if(opts && opts.mode && opts.mode.toLowerCase() === 'bypass') {
       const guid = Utils.guid();
       const method = (opts.method && opts.method.toUpperCase()) || 'GET';
+      const headers = {};
 
-      console.log(method);
+      for (var header of opts.headers.entries()) {
+        headers[header[0]] = header[1];
+      }
 
-      const request = {
-        method: method,
-        guid: guid,
-        url: url
-      };
-  
+      const request = { method: method, guid: guid, url: url, body: opts.body, headers: headers };
+
       // call to native layer for fetch
-      NativeModules.SyrNetworking.get(request);
+      NativeModules.SyrNetworking.request(request);
       return {
         then: (cb)=>{
           request.cb = cb;

--- a/lib/networking.js
+++ b/lib/networking.js
@@ -58,6 +58,14 @@ class networking {
   }
   requestHandler(event) {
     const body = event.body;
+
+    if(!this.requests[body.guid]) {
+      setTimeout(
+        ()=>this.requestHandler(event)
+      , 20); // make sure we have cb ready before we fire it
+      return;
+    }
+
     const req = this.requests[body.guid];
     const response = {
       status: body.responseCode,


### PR DESCRIPTION
tests to follow

added a mode 'bypass'. The fetch will be intercepted.

Current notes, the filled fetch is not compatible with the full API, Request or Header objects. Please use object literals for now.

```
const authCredentials = {
  'Accept': 'application/json',
  'Content-Type' : 'application/json',
  'x-paypal-internal-euat' : 'access_token',
  'paypal-client-context' : 'ec_token'
};


fetch('http://httpbin.org/post', {
  method: 'POST',
  mode:'bypass',
  body: JSON.stringify({ query: 'true' }),
  headers: new Headers(authCredentials)
}).then(response => {
  console.log(response.json())
});

```

<img width="404" alt="screen shot 2018-02-07 at 11 09 11 pm" src="https://user-images.githubusercontent.com/328000/35960566-fc45e3a8-0c5e-11e8-9c53-96e21007f66b.png">
