### PR TITLE
fixes scroll calcs for stackview when stackview height is calculated

### DIFF
--- a/ios/SyrNative/SyrNative/SyrStackView.m
+++ b/ios/SyrNative/SyrNative/SyrStackView.m
@@ -65,6 +65,14 @@ SYR_EXPORT_MODULE(StackView)
     	CGRect frame = stackView.frame;
     	frame.size.height = [totalHeight doubleValue];
     	stackView.frame = frame;
+    
+    	// this is stupid and dumb work around
+    	// we need a better notification to parents, to resize
+    	if([stackView.superview isKindOfClass:[UIScrollView class]]) {
+        UIScrollView* parent = (UIScrollView*)stackView.superview;
+        double scrollheight = [totalHeight doubleValue] + 50;
+        parent.contentSize = CGSizeMake(parent.frame.size.width, scrollheight);
+    	}
   }
   
   return [SyrStyler styleView:stackView withStyle:style];


### PR DESCRIPTION
This fix is less than ideal but corrects ScrollView's content calculation when a StackView auto calculates it's height. 

todo : is to bump this out into a better child-parent notifier. 